### PR TITLE
Fix a memory mapping bug in sbull.c

### DIFF
--- a/sbull/sbull.c
+++ b/sbull/sbull.c
@@ -137,7 +137,7 @@ static int sbull_xfer_bio(struct sbull_dev *dev, struct bio *bio)
 		sbull_transfer(dev, sector, bio_cur_bytes(bio) >> 9,
 				buffer, bio_data_dir(bio) == WRITE);
 		sector += bio_cur_bytes(bio) >> 9;
-		__bio_kunmap_atomic(bio, KM_USER0);
+		__bio_kunmap_atomic(buffer, KM_USER0);
 	}
 	return 0; /* Always "succeed" */
 }


### PR DESCRIPTION
There is a bug related to temporary kernel mapping in `sbull.c`.

The marco `__bio_kunmap_atomic`, which actually calls `kunmap_atomic`, should pass the linear address corresponding to the mapped memory rather than the address of a `bio` structure.

The bug compromises the page table. If you write to a sbull device many times, this bug will cause a Linux oops. 
