### PR TITLE
Fixed failure to load scull module and description typo in scull.init.

### DIFF
--- a/scull/scull.init
+++ b/scull/scull.init
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Sample init script for the a driver module <rubini@linux.it>
+# Sample init script for the scull driver module <rubini@linux.it>
 
 DEVICE="scull"
 SECTION="misc"
@@ -88,10 +88,10 @@ function remove_files () {
 # Load and create files
 function load_device () {
     
-    if [ -f $MODDIR/$DEVICE.o ]; then
-	devpath=$MODDIR/$DEVICE.o
-    else if [ -f ./$DEVICE.o ]; then
-	devpath=./$DEVICE.o
+    if [ -f $MODDIR/$DEVICE.ko ]; then
+	devpath=$MODDIR/$DEVICE.ko
+    else if [ -f ./$DEVICE.ko ]; then
+	devpath=./$DEVICE.ko
     else
 	devpath=$DEVICE; # let insmod/modprobe guess
     fi; fi


### PR DESCRIPTION
The scull.init initialization file fails to load scull module because
it tries to load modules in the configured paths with .o suffix instead
of .ko.
