### PR TITLE
Fix failure to compile the scull with kernel of version 4.6.0.

### DIFF
--- a/scull/access.c
+++ b/scull/access.c
@@ -105,15 +105,15 @@ static int scull_u_open(struct inode *inode, struct file *filp)
 
 	spin_lock(&scull_u_lock);
 	if (scull_u_count && 
-	                (scull_u_owner != current_uid()) &&  /* allow user */
-	                (scull_u_owner != current_euid()) && /* allow whoever did su */
+	                (scull_u_owner != current_uid().val) &&  /* allow user */
+	                (scull_u_owner != current_euid().val) && /* allow whoever did su */
 			!capable(CAP_DAC_OVERRIDE)) { /* still allow root */
 		spin_unlock(&scull_u_lock);
 		return -EBUSY;   /* -EPERM would confuse the user */
 	}
 
 	if (scull_u_count == 0)
-		scull_u_owner = current_uid(); /* grab it */
+		scull_u_owner = current_uid().val; /* grab it */
 
 	scull_u_count++;
 	spin_unlock(&scull_u_lock);
@@ -164,8 +164,8 @@ static DEFINE_SPINLOCK(scull_w_lock);
 static inline int scull_w_available(void)
 {
 	return scull_w_count == 0 ||
-		scull_w_owner == current_uid() ||
-		scull_w_owner == current_euid() ||
+		scull_w_owner == current_uid().val ||
+		scull_w_owner == current_euid().val ||
 		capable(CAP_DAC_OVERRIDE);
 }
 
@@ -183,7 +183,7 @@ static int scull_w_open(struct inode *inode, struct file *filp)
 		spin_lock(&scull_w_lock);
 	}
 	if (scull_w_count == 0)
-		scull_w_owner = current_uid(); /* grab it */
+		scull_w_owner = current_uid().val; /* grab it */
 	scull_w_count++;
 	spin_unlock(&scull_w_lock);
 


### PR DESCRIPTION
Fix failure to compile the scull. 
The  type of return value of current_xid() has changed in kernel of version 4.6.0, so we can't compare the two values with different types.
