### PR TITLE
Support 5.x kernels

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+    	
+    <storageModule moduleId="org.eclipse.cdt.core.settings">
+        		
+        <cconfiguration id="cdt.managedbuild.toolchain.gnu.base.15621689">
+            			
+            <storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.base.15621689" moduleId="org.eclipse.cdt.core.settings" name="Default">
+                				
+                <externalSettings/>
+                				
+                <extensions>
+                    					
+                    <extension id="org.eclipse.cdt.core.GNU_ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+                    					
+                    <extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+                    				
+                </extensions>
+                			
+            </storageModule>
+            			
+            <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+                				
+                <configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.base.15621689" name="Default" parent="org.eclipse.cdt.build.core.emptycfg">
+                    					
+                    <folderInfo id="cdt.managedbuild.toolchain.gnu.base.15621689.1525485504" name="/" resourcePath="">
+                        						
+                        <toolChain id="cdt.managedbuild.toolchain.gnu.base.2101552209" name="Linux GCC" superClass="cdt.managedbuild.toolchain.gnu.base">
+                            							
+                            <targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.GNU_ELF" id="cdt.managedbuild.target.gnu.platform.base.1749325537" name="Debug Platform" osList="linux,hpux,aix,qnx" superClass="cdt.managedbuild.target.gnu.platform.base"/>
+                            							
+                            <builder id="cdt.managedbuild.target.gnu.builder.base.1687159127" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.base"/>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.archiver.base.1178340965" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.cpp.compiler.base.630384264" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.include.paths.1180383697" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include/uapi}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.cpp.compiler.option.preprocessor.def.837001881" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+                                    									
+                                    <listOptionValue builtIn="false" value="__KERNEL__=1"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.678381649" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+                                							
+                            </tool>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.c.compiler.base.622305353" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.base">
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.include.paths.431759876" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include/uapi}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.c.compiler.option.preprocessor.def.symbols.392724985" name="Defined symbols (-D)" superClass="gnu.c.compiler.option.preprocessor.def.symbols" useByScannerDiscovery="false" valueType="definedSymbols">
+                                    									
+                                    <listOptionValue builtIn="false" value="__KERNEL__=1"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.615424973" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+                                							
+                            </tool>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.c.linker.base.1737934968" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.base"/>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.cpp.linker.base.276121405" name="GCC C++ Linker" superClass="cdt.managedbuild.tool.gnu.cpp.linker.base">
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.657273137" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+                                    									
+                                    <additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+                                    									
+                                    <additionalInput kind="additionalinput" paths="$(LIBS)"/>
+                                    								
+                                </inputType>
+                                							
+                            </tool>
+                            							
+                            <tool id="cdt.managedbuild.tool.gnu.assembler.base.2023794764" name="GCC Assembler" superClass="cdt.managedbuild.tool.gnu.assembler.base">
+                                								
+                                <option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="gnu.both.asm.option.include.paths.2127941785" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include}&quot;"/>
+                                    									
+                                    <listOptionValue builtIn="false" value="&quot;${workspace_loc:/ldd3/linux_source_cdt/arch/x86/include/uapi}&quot;"/>
+                                    								
+                                </option>
+                                								
+                                <inputType id="cdt.managedbuild.tool.gnu.assembler.input.1044785806" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+                                							
+                            </tool>
+                            						
+                        </toolChain>
+                        					
+                    </folderInfo>
+                    					
+                    <sourceEntries>
+                        						
+                        <entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
+                        					
+                    </sourceEntries>
+                    				
+                </configuration>
+                			
+            </storageModule>
+            			
+            <storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+            		
+        </cconfiguration>
+        	
+    </storageModule>
+    	
+    <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+        		
+        <project id="ldd3.null.1071819988" name="ldd3"/>
+        	
+    </storageModule>
+    	
+    <storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+    	
+    <storageModule moduleId="refreshScope" versionNumber="2">
+        		
+        <configuration configurationName="Default">
+            			
+            <resource resourceType="PROJECT" workspacePath="/ldd3"/>
+            		
+        </configuration>
+        	
+    </storageModule>
+    	
+    <storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
+    	
+    <storageModule moduleId="scannerConfiguration">
+        		
+        <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+        		
+        <scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.base.15621689;cdt.managedbuild.toolchain.gnu.base.15621689.1525485504;cdt.managedbuild.tool.gnu.c.compiler.base.622305353;cdt.managedbuild.tool.gnu.c.compiler.input.615424973">
+            			
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        		
+        <scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.base.15621689;cdt.managedbuild.toolchain.gnu.base.15621689.1525485504;cdt.managedbuild.tool.gnu.cpp.compiler.base.630384264;cdt.managedbuild.tool.gnu.cpp.compiler.input.678381649">
+            			
+            <autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+            		
+        </scannerConfigBuildInfo>
+        	
+    </storageModule>
+    	
+    <storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+    
+</cproject>

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ outp
 datasize
 dataalign
 netifdebug
+
+# Allows for Eclipse CDT lookups without checking in linux source
+linux_src_cdt/*
+!.project
+!.cproject

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ outp
 datasize
 dataalign
 netifdebug
+asynctest
 
 # Allows for Eclipse CDT lookups without checking in linux source
 linux_source_cdt

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,6 @@ dataalign
 netifdebug
 
 # Allows for Eclipse CDT lookups without checking in linux source
-linux_src_cdt/*
+linux_source_cdt
 !.project
 !.cproject

--- a/.project
+++ b/.project
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ldd3</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
-SUBDIRS =  misc-progs misc-modules \
-           skull scull scullc sculld scullp scullv sbull snull\
-	   short shortprint pci simple usb tty lddbus
+# disabled (not compiling on 5.0+): misc-modules sbull snull sculld scullp scullv short shortprint simple tty 
+SUBDIRS =  misc-progs \
+           skull scull scullc \
+	   pci usb lddbus
 
 all: subdirs
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
-# disabled (not compiling on 5.0+): sbull snull sculld scullp scullv short shortprint simple tty
+# disabled (not compiling on 5.0+): sbull snull short
 SUBDIRS =  misc-progs misc-modules \
-           skull scull scullc \
+           skull scull scullc scullp sculld scullv shortprint simple tty \
 	   pci usb lddbus
 
 all: subdirs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-# disabled (not compiling on 5.0+): misc-modules sbull snull sculld scullp scullv short shortprint simple tty 
-SUBDIRS =  misc-progs \
+# disabled (not compiling on 5.0+): sbull snull sculld scullp scullv short shortprint simple tty
+SUBDIRS =  misc-progs misc-modules \
            skull scull scullc \
 	   pci usb lddbus
 

--- a/README
+++ b/README
@@ -26,3 +26,14 @@ $ cd ldd3
 $ make
 
 Bugs, comments or patches: martinez.javier@gmail.com
+
+Eclipse Integration
+---------
+Eclipse CDT integration is provided by symlinking the correct linux source directory with the ./linux_source_cdt symlink.
+The .project and .cproject files were setup using instructions in [this link](https://wiki.eclipse.org/HowTo_use_the_CDT_to_navigate_Linux_kernel_source)
+and assuming a symlink is setup in the local project directory to point to relevant kernel headers
+
+This can be done on a system with kernel headers installed using:
+```
+ln -s /usr/src/linux-headers-`uname -r`/ linux_source_cdt
+```

--- a/include/access_ok_version.h
+++ b/include/access_ok_version.h
@@ -1,0 +1,31 @@
+/*
+ * @file access_ok_version.h
+ * @date 10/13/2019
+ * 
+ */
+
+
+#include <linux/uaccess.h>
+#include <linux/version.h>
+
+
+/*
+ * Wrapper function which drops the third argument on kernel 5.0 or later
+ */
+
+inline int access_ok_wrapper(int type, void __user * arg, unsigned int cmd)
+{
+	int err =0;
+
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+
+	err = access_ok(type, (void __user *)arg, cmd);
+
+	#else
+
+	err = access_ok((void __user *)arg, cmd);
+
+	#endif
+
+	return err;
+}

--- a/include/access_ok_version.h
+++ b/include/access_ok_version.h
@@ -1,31 +1,15 @@
 /*
  * @file access_ok_version.h
  * @date 10/13/2019
- * 
+ *
  */
 
-
-#include <linux/uaccess.h>
 #include <linux/version.h>
 
-
-/*
- * Wrapper function which drops the third argument on kernel 5.0 or later
- */
-
-inline int access_ok_wrapper(int type, void __user * arg, unsigned int cmd)
-{
-	int err =0;
-
-	#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
-
-	err = access_ok(type, (void __user *)arg, cmd);
-
-	#else
-
-	err = access_ok((void __user *)arg, cmd);
-
-	#endif
-
-	return err;
-}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
+#define access_ok_wrapper(type,arg,cmd) \
+	access_ok(type, arg, cmd)
+#else
+#define access_ok_wrapper(type,arg,cmd) \
+	access_ok(arg, cmd)
+#endif

--- a/init
+++ b/init
@@ -1,0 +1,21 @@
+#! /bin/sh
+
+
+case "$1" in
+start)
+echo "Starting init script for Module Loading"
+start-stop-daemon -S -n init -a /bin/scull_load
+start-stop-daemon -S -n init -a /bin/module_load -- hello
+;;
+stop)
+echo "Removing user modules"
+start-stop-daemon -K -n scull_load
+start-stop-daemon -K -n module_load
+start-stop-daemon -S -n init -a /bin/scull_unload
+start-stop-daemon -S -n init -a /bin/module_unload -- hello
+;;
+*)
+echo "Usage: $0 {start|stop}"
+exit 1
+esac
+exit 0

--- a/lddbus/Makefile
+++ b/lddbus/Makefile
@@ -22,7 +22,7 @@ KERNELDIR ?= /lib/modules/$(shell uname -r)/build
 PWD       := $(shell pwd)
 
 default:
-	$(MAKE) -C $(KERNELDIR) SUBDIRS=$(PWD) modules
+	$(MAKE) -C $(KERNELDIR) M=$(PWD) modules
 
 endif
 

--- a/linux_source_cdt
+++ b/linux_source_cdt
@@ -1,1 +1,0 @@
-/usr/src/linux-headers-5.0.0-29/

--- a/linux_source_cdt
+++ b/linux_source_cdt
@@ -1,0 +1,1 @@
+/usr/src/linux-headers-5.0.0-29/

--- a/misc-modules/Makefile
+++ b/misc-modules/Makefile
@@ -27,7 +27,7 @@ else
     # called from kernel build system: just declare what our modules are
     # disabled due to compile errors: jit.o
     obj-m := hello.o hellop.o seq.o jiq.o sleepy.o complete.o \
-             silly.o faulty.o kdatasize.o kdataalign.o
+             silly.o faulty.o kdatasize.o kdataalign.o jit.o
 endif
 
 

--- a/misc-modules/Makefile
+++ b/misc-modules/Makefile
@@ -25,7 +25,8 @@ clean:
 
 else
     # called from kernel build system: just declare what our modules are
-    obj-m := hello.o hellop.o seq.o jit.o jiq.o sleepy.o complete.o \
+    # disabled due to compile errors: jit.o
+    obj-m := hello.o hellop.o seq.o jiq.o sleepy.o complete.o \
              silly.o faulty.o kdatasize.o kdataalign.o
 endif
 

--- a/misc-modules/Makefile
+++ b/misc-modules/Makefile
@@ -25,8 +25,7 @@ clean:
 
 else
     # called from kernel build system: just declare what our modules are
-    # disabled due to compile errors: jit.o
-    obj-m := hello.o hellop.o seq.o jiq.o sleepy.o complete.o \
+    obj-m := hello.o hellop.o seq.o jit.o jiq.o sleepy.o complete.o \
              silly.o faulty.o kdatasize.o kdataalign.o jit.o
 endif
 

--- a/misc-modules/hello.c
+++ b/misc-modules/hello.c
@@ -8,7 +8,6 @@ MODULE_LICENSE("Dual BSD/GPL");
 static int hello_init(void)
 {
 	printk(KERN_ALERT "Hello, world\n");
-	printk(KERN_ALERT "Github: ECEN5013\n");
 	return 0;
 }
 

--- a/misc-modules/hello.c
+++ b/misc-modules/hello.c
@@ -8,6 +8,7 @@ MODULE_LICENSE("Dual BSD/GPL");
 static int hello_init(void)
 {
 	printk(KERN_ALERT "Hello, world\n");
+	printk(KERN_ALERT "Github: ECEN5013");
 	return 0;
 }
 

--- a/misc-modules/hello.c
+++ b/misc-modules/hello.c
@@ -8,7 +8,7 @@ MODULE_LICENSE("Dual BSD/GPL");
 static int hello_init(void)
 {
 	printk(KERN_ALERT "Hello, world\n");
-	printk(KERN_ALERT "Github: ECEN5013");
+	printk(KERN_ALERT "Github: ECEN5013\n");
 	return 0;
 }
 

--- a/misc-modules/module_load
+++ b/misc-modules/module_load
@@ -1,0 +1,26 @@
+#!/bin/sh
+module=$1
+device=$1
+mode="664"
+
+if [ $# -ne 1 ]; then
+	echo "Wrong number of arguments"
+	echo "usage: $0 module_name"
+	echo "Will create a corresponding device /dev/module_name associated with module_name.ko"
+	exit 1
+fi
+
+set -e
+# Group: since distributions do it differently, look for wheel or use staff
+if grep -q '^staff:' /etc/group; then
+    group="staff"
+else
+    group="wheel"
+fi
+
+insmod ./$module.ko $* || exit 1
+major=$(awk "\$2==\"$module\" {print \$1}" /proc/devices)
+rm -f /dev/${device}
+mknod /dev/${device} c $major 0
+chgrp $group /dev/${device}
+chmod $mode  /dev/${device}

--- a/misc-modules/module_unload
+++ b/misc-modules/module_unload
@@ -1,0 +1,17 @@
+#!/bin/sh
+module=$1
+device=$1
+
+if [ $# -ne 1 ]; then
+	echo "Wrong number of arguments"
+	echo "usage: $0 module_name"
+	echo "Will unload the module specified by module_name and remove assocaited device"
+	exit 1
+fi
+
+# invoke rmmod with all arguments we got
+rmmod $module || exit 1
+
+# Remove stale nodes
+
+rm -f /dev/${device}

--- a/misc-progs/Makefile
+++ b/misc-progs/Makefile
@@ -1,5 +1,5 @@
 
-FILES = nbtest load50 mapcmp polltest mapper setlevel setconsole inp outp \
+FILES = asynctest nbtest load50 mapcmp polltest mapper setlevel setconsole inp outp \
 	datasize dataalign netifdebug
 
 KERNELDIR ?= /lib/modules/$(shell uname -r)/build

--- a/misc-progs/asynctest.c
+++ b/misc-progs/asynctest.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
             continue;
         count=read(0, buffer, 4096);
         /* buggy: if avail data is more than 4kbytes... */
-        write(1,buffer,count);
+        count=write(1,buffer,count);
         gotdata=0;
     }
 }

--- a/misc-progs/test/.gitignore
+++ b/misc-progs/test/.gitignore
@@ -1,0 +1,2 @@
+infile
+outfile

--- a/misc-progs/test/nonblock.sh
+++ b/misc-progs/test/nonblock.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+infile=infile
+delay=1
+outfile=outfile
+strace=
+
+function printusage
+{
+	echo "Usage: $0 [-i infile] [-d delay ] [-o outfile] [-s]"
+	echo "  Writes outfile in non-blocking mode with the content of infile as it is updated"
+	echo "  polling for changes to the file after delay seconds"
+	echo "  When -s is specified, strace is used to trace the command"
+	echo "  device default is ${device}"
+	echo "  infile default is ${infile}"
+	echo "  delay default is ${delay} seconds"
+	echo "  See Linux Device Drivers 3rd Edition chapter 6 section \"Testing the Scullpipe Driver\""
+	echo "  For example, to test non blocking IO on /dev/scullpipe for both read and write, you can:"
+	echo "		Open one terminal window and enter command ./misc-progs/test/nonblock.sh -o /dev/scullpipe -s"
+	echo "		Open a second terminal window and enter command ./misc-progs/test/nonblock.sh -i /dev/scullpipe -s"
+	echo "		Open a 3rd terminal window and enter command tail -f  ./misc-progs/test/outfile"
+	echo "		Open a 4th terminal window and ender command echo \"Hello World!\" >> ./misc-progs/test/infile"
+	echo "		* You should see continuous polling at the rate specified by the delay argument on each"
+	echo "			endpoint."
+	echo "		* You should see the output moved from infile to outfile as each echo command is sent"
+	echo "		* When building with DEBUG=y in the makefile, you should see debug messages in kern.log"
+	echo "			indicating the utility nbtest read/wrote bytes successfully"
+}
+
+while getopts "i:o:d:sh" opt; do
+	case ${opt} in
+		i )
+			infile=$OPTARG
+			;;
+		d )
+			delay=$OPTARG
+			;;
+		o )
+			outfile=$OPTARG
+			;;
+		s )
+			strace=strace
+			;;
+		h )
+			printusage
+			exit 0
+			;;
+
+		\? )
+			echo "Invalid option $OPTARG" 1>&2
+			printusage
+			exit 1
+			;;
+		: )
+			echo "Invalid option $OPTARG requires an argument" 1>&2
+			printusage
+			exit 1
+			;;
+	esac
+done
+
+set -e
+cd `dirname $0`
+touch ${infile}
+echo "Reading content of ${infile} through non blocking test to ${outfile}"
+echo "${strace} ../nbtest ${delay} > ${outfile} < ${infile}"
+${strace} ../nbtest ${delay} > ${outfile} < ${infile}

--- a/scull-shared/scull-async.c
+++ b/scull-shared/scull-async.c
@@ -1,0 +1,88 @@
+/*
+ * scull-async.c
+ *
+ * Copyright (C) 2019 Dan Walkes
+ * Copyright (C) 2001 Alessandro Rubini and Jonathan Corbet
+ * Copyright (C) 2001 O'Reilly & Associates
+ *
+ * The source code in this file can be freely used, adapted,
+ * and redistributed in source or binary form, so long as an
+ * acknowledgment appears in derived source files.  The citation
+ * should list that the code comes from the book "Linux Device
+ * Drivers" by Alessandro Rubini and Jonathan Corbet, published
+ * by O'Reilly & Associates.   No warranty is attached;
+ * we cannot take responsibility for errors or fitness for use.
+ */
+
+#include <linux/module.h>
+#include <linux/moduleparam.h>
+#include <linux/init.h>
+#include <linux/kernel.h>	/* printk() */
+#include <linux/slab.h>		/* kmalloc() */
+#include <linux/fs.h>		/* everything... */
+#include <linux/errno.h>	/* error codes */
+#include <linux/types.h>	/* size_t */
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/fcntl.h>	/* O_ACCMODE */
+#include <linux/aio.h>
+#include <linux/uaccess.h>
+#include <linux/uio.h>	/* iov_iter* */
+
+
+/*
+ * A simple asynchronous I/O implementation.
+ */
+
+struct async_work {
+	struct delayed_work work;
+	struct kiocb *iocb;
+	struct iov_iter *tofrom;
+};
+
+/*
+ * "Complete" an asynchronous operation.
+ */
+static void scull_do_deferred_op(struct work_struct *work)
+{
+	struct async_work *stuff = container_of(work, struct async_work, work.work);
+	if( iov_iter_rw(stuff->tofrom) == WRITE ) {
+		generic_file_write_iter(stuff->iocb, stuff->tofrom);
+	} else {
+		generic_file_read_iter(stuff->iocb, stuff->tofrom);
+	}
+	kfree(stuff);
+}
+
+
+static int scull_defer_op(struct kiocb *iocb, struct iov_iter *tofrom)
+{
+	struct async_work *stuff;
+	int result;
+	/* Otherwise defer the completion for a few milliseconds. */
+	stuff = kmalloc (sizeof (*stuff), GFP_KERNEL);
+	if (stuff == NULL)
+		return result; /* No memory, just complete now */
+	stuff->iocb = iocb;
+	INIT_DELAYED_WORK(&stuff->work, scull_do_deferred_op);
+	schedule_delayed_work(&stuff->work, HZ/100);
+	return -EIOCBQUEUED;
+}
+
+
+ssize_t scull_read_iter(struct kiocb *iocb, struct iov_iter *to)
+{
+	/* If this is a synchronous IOCB, we return our status now. */
+	if (is_sync_kiocb(iocb)) {
+		return generic_file_read_iter(iocb,to);
+	}
+	return scull_defer_op(iocb, to);
+}
+
+ssize_t scull_write_iter(struct kiocb *iocb, struct iov_iter *from)
+{
+	if (is_sync_kiocb(iocb)) {
+		return generic_file_write_iter(iocb,from);
+	}
+	return scull_defer_op(iocb, from);
+}

--- a/scull-shared/scull-async.h
+++ b/scull-shared/scull-async.h
@@ -1,0 +1,25 @@
+/*
+ * scull-async.h
+ *
+ * Copyright (C) 2019 Dan Walkes
+ * Copyright (C) 2001 Alessandro Rubini and Jonathan Corbet
+ * Copyright (C) 2001 O'Reilly & Associates
+ *
+ * The source code in this file can be freely used, adapted,
+ * and redistributed in source or binary form, so long as an
+ * acknowledgment appears in derived source files.  The citation
+ * should list that the code comes from the book "Linux Device
+ * Drivers" by Alessandro Rubini and Jonathan Corbet, published
+ * by O'Reilly & Associates.   No warranty is attached;
+ * we cannot take responsibility for errors or fitness for use.
+ */
+
+#ifndef SCULL_SHARED_SCULL_ASYNC_H_
+#define SCULL_SHARED_SCULL_ASYNC_H_
+
+
+ssize_t scull_write_iter(struct kiocb *iocb, struct iov_iter *from);
+ssize_t scull_read_iter(struct kiocb *iocb, struct iov_iter *to);
+
+
+#endif /* SCULL_SHARED_SCULL_ASYNC_H_ */

--- a/scull/access.c
+++ b/scull/access.c
@@ -264,7 +264,7 @@ static struct scull_dev *scull_c_lookfor_device(dev_t key)
 	memset(lptr, 0, sizeof(struct scull_listitem));
 	lptr->key = key;
 	scull_trim(&(lptr->device)); /* initialize it */
-	sema_init(&(lptr->device.sem), 1);
+	mutex_init(&lptr->device.lock);
 
 	/* place it in the list */
 	list_add(&lptr->list, &scull_c_list);
@@ -350,7 +350,7 @@ static void scull_access_setup (dev_t devno, struct scull_adev_info *devinfo)
 	/* Initialize the device structure */
 	dev->quantum = scull_quantum;
 	dev->qset = scull_qset;
-	sema_init(&dev->sem, 1);
+	mutex_init(&dev->lock);
 
 	/* Do the cdev stuff. */
 	cdev_init(&dev->cdev, devinfo->fops);

--- a/scull/main.c
+++ b/scull/main.c
@@ -411,9 +411,9 @@ long scull_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	if (err) return -EFAULT;
 
 	switch(cmd) {

--- a/scull/main.c
+++ b/scull/main.c
@@ -31,6 +31,7 @@
 #include <linux/uaccess.h>	/* copy_*_user */
 
 #include "scull.h"		/* local definitions */
+#include "access_ok_version.h"
 
 /*
  * Our parameters which can be set at load time.
@@ -411,9 +412,9 @@ long scull_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok_wrapper(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok_wrapper(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
 	if (err) return -EFAULT;
 
 	switch(cmd) {

--- a/scull/main.c
+++ b/scull/main.c
@@ -93,7 +93,7 @@ int scull_read_procmem(struct seq_file *s, void *v)
         for (i = 0; i < scull_nr_devs && s->count <= limit; i++) {
                 struct scull_dev *d = &scull_devices[i];
                 struct scull_qset *qs = d->data;
-                if (down_interruptible(&d->lock))
+                if (mutex_lock_interruptible(&d->lock))
                         return -ERESTARTSYS;
                 seq_printf(s,"\nDevice %i: qset %i, q %i, sz %li\n",
                              i, d->qset, d->quantum, d->size);
@@ -107,7 +107,7 @@ int scull_read_procmem(struct seq_file *s, void *v)
                                                              j, qs->data[j]);
                                 }
                 }
-                up(&scull_devices[i].lock);
+                mutex_unlock(&scull_devices[i].lock);
         }
         return 0;
 }
@@ -144,7 +144,7 @@ static int scull_seq_show(struct seq_file *s, void *v)
 	struct scull_qset *d;
 	int i;
 
-	if (down_interruptible(&dev->lock))
+	if (mutex_lock_interruptible(&dev->lock))
 		return -ERESTARTSYS;
 	seq_printf(s, "\nDevice %i: qset %i, q %i, sz %li\n",
 			(int) (dev - scull_devices), dev->qset,
@@ -158,7 +158,7 @@ static int scull_seq_show(struct seq_file *s, void *v)
 							i, d->data[i]);
 			}
 	}
-	up(&dev->lock);
+	mutex_unlock(&dev->lock);
 	return 0;
 }
 	

--- a/scull/pipe.c
+++ b/scull/pipe.c
@@ -274,14 +274,14 @@ static int scull_read_p_mem(struct seq_file *s, void *v)
 	seq_printf(s, "Default buffersize is %i\n", scull_p_buffer);
 	for(i = 0; i<scull_p_nr_devs && s->count <= LIMIT; i++) {
 		p = &scull_p_devices[i];
-		if (down_interruptible(&p->lock))
+		if (mutex_lock_interruptible(&p->lock))
 			return -ERESTARTSYS;
 		seq_printf(s, "\nDevice %i: %p\n", i, p);
 /*		seq_printf(s, "   Queues: %p %p\n", p->inq, p->outq);*/
 		seq_printf(s, "   Buffer: %p to %p (%i bytes)\n", p->buffer, p->end, p->buffersize);
 		seq_printf(s, "   rp %p   wp %p\n", p->rp, p->wp);
 		seq_printf(s, "   readers %i   writers %i\n", p->nreaders, p->nwriters);
-		up(&p->lock);
+		mutex_unlock(&p->lock);
 	}
 	return 0;
 }

--- a/scull/scull.h
+++ b/scull/scull.h
@@ -90,7 +90,7 @@ struct scull_dev {
 	int qset;                 /* the current array size */
 	unsigned long size;       /* amount of data stored here */
 	unsigned int access_key;  /* used by sculluid and scullpriv */
-	struct semaphore sem;     /* mutual exclusion semaphore     */
+	struct mutex lock;     /* mutual exclusion semaphore     */
 	struct cdev cdev;	  /* Char device structure		*/
 };
 

--- a/scullc/Makefile
+++ b/scullc/Makefile
@@ -16,7 +16,7 @@ TARGET = scullc
 
 ifneq ($(KERNELRELEASE),)
 
-scullc-objs := main.o
+scullc-objs := main.o scull-shared/scull-async.o
 
 obj-m	:= scullc.o
 

--- a/scullc/main.c
+++ b/scullc/main.c
@@ -283,9 +283,9 @@ long scullc_ioctl (struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	if (err)
 		return -EFAULT;
 

--- a/scullc/mmap.c
+++ b/scullc/mmap.c
@@ -64,7 +64,7 @@ struct page *scullc_vma_nopage(struct vm_area_struct *vma,
 	struct page *page = NOPAGE_SIGBUS;
 	void *pageptr = NULL; /* default to "missing" */
 
-	down(&dev->sem);
+	mutex_lock(&dev->lock);
 	offset = (address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
@@ -86,7 +86,7 @@ struct page *scullc_vma_nopage(struct vm_area_struct *vma,
 	if (type)
 		*type = VM_FAULT_MINOR;
   out:
-	up(&dev->sem);
+	mutex_unlock(&dev->lock);
 	return page;
 }
 

--- a/scullc/scull-shared/scull-async.c
+++ b/scullc/scull-shared/scull-async.c
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.c

--- a/scullc/scull-shared/scull-async.h
+++ b/scullc/scull-shared/scull-async.h
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.h

--- a/scullc/scullc.h
+++ b/scullc/scullc.h
@@ -59,7 +59,7 @@ struct scullc_dev {
 	int quantum;              /* the current allocation size */
 	int qset;                 /* the current array size */
 	size_t size;              /* 32-bit will suffice */
-	struct semaphore sem;     /* Mutual exclusion */
+	struct mutex lock;     /* Mutual exclusion */
 	struct cdev cdev;
 };
 

--- a/sculld/Makefile
+++ b/sculld/Makefile
@@ -16,7 +16,7 @@ TARGET = sculld
 
 ifneq ($(KERNELRELEASE),)
 
-sculld-objs := main.o mmap.o
+sculld-objs := main.o mmap.o scull-shared/scull-async.o
 
 obj-m	:= sculld.o
 

--- a/sculld/main.c
+++ b/sculld/main.c
@@ -289,9 +289,9 @@ long sculld_ioctl (struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	if (err)
 		return -EFAULT;
 

--- a/sculld/mmap.c
+++ b/sculld/mmap.c
@@ -56,16 +56,17 @@ void sculld_vma_close(struct vm_area_struct *vma)
  * is individually decreased, and would drop to 0.
  */
 
-static int sculld_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int sculld_vma_nopage(struct vm_fault *vmf)
 {
 	unsigned long offset;
+	struct vm_area_struct *vma = vmf->vma;
 	struct sculld_dev *ptr, *dev = vma->vm_private_data;
 	struct page *page = NULL;
 	void *pageptr = NULL; /* default to "missing" */
 	int retval = VM_FAULT_NOPAGE;
 
-	down(&dev->sem);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	mutex_lock(&dev->mutex);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*
@@ -87,7 +88,7 @@ static int sculld_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
 	retval = 0;
 
   out:
-	up(&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 

--- a/sculld/scull-shared/scull-async.c
+++ b/sculld/scull-shared/scull-async.c
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.c

--- a/sculld/scull-shared/scull-async.h
+++ b/sculld/scull-shared/scull-async.h
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.h

--- a/sculld/sculld.h
+++ b/sculld/sculld.h
@@ -61,7 +61,7 @@ struct sculld_dev {
 	int order;                /* the current allocation order */
 	int qset;                 /* the current array size */
 	size_t size;              /* 32-bit will suffice */
-	struct semaphore sem;     /* Mutual exclusion */
+	struct mutex mutex;     /* Mutual exclusion */
 	struct cdev cdev;
 	char devname[20];
 	struct ldd_device ldev;

--- a/scullp/Makefile
+++ b/scullp/Makefile
@@ -16,7 +16,7 @@ TARGET = scullp
 
 ifneq ($(KERNELRELEASE),)
 
-scullp-objs := main.o mmap.o
+scullp-objs := main.o mmap.o scull-shared/scull-async.o
 
 obj-m	:= scullp.o
 

--- a/scullp/main.c
+++ b/scullp/main.c
@@ -28,7 +28,9 @@
 #include <linux/fcntl.h>	/* O_ACCMODE */
 #include <linux/aio.h>
 #include <linux/uaccess.h>
+#include <linux/uio.h>	/* ivo_iter* */
 #include "scullp.h"		/* local definitions */
+#include "scull-shared/scull-async.h"
 
 
 int scullp_major =   SCULLP_MAJOR;
@@ -67,7 +69,7 @@ int scullp_read_procmem(struct seq_file *m, void *v)
 
 	for(i = 0; i < scullp_devs; i++) {
 		d = &scullp_devices[i];
-		if (down_interruptible (&d->sem))
+		if (down_interruptible (&d->mutex))
 			return -ERESTARTSYS;
 		qset = d->qset;  /* retrieve the features of each device */
 		order = d->order;
@@ -86,7 +88,7 @@ int scullp_read_procmem(struct seq_file *m, void *v)
 				}
 		}
 	  out:
-		up (&scullp_devices[i].sem);
+		up (&scullp_devices[i].mutex);
 		if (m->count > limit)
 			break;
 	}
@@ -121,10 +123,10 @@ int scullp_open (struct inode *inode, struct file *filp)
 
     	/* now trim to 0 the length of the device if open was write-only */
 	if ( (filp->f_flags & O_ACCMODE) == O_WRONLY) {
-		if (down_interruptible (&dev->sem))
+		if (mutex_lock_interruptible(&dev->mutex))
 			return -ERESTARTSYS;
 		scullp_trim(dev); /* ignore errors */
-		up (&dev->sem);
+		mutex_unlock(&dev->mutex);
 	}
 
 	/* and use filp->private_data to point to the device data */
@@ -169,7 +171,7 @@ ssize_t scullp_read (struct file *filp, char __user *buf, size_t count,
 	int item, s_pos, q_pos, rest;
 	ssize_t retval = 0;
 
-	if (down_interruptible (&dev->sem))
+	if (mutex_lock_interruptible(&dev->mutex))
 		return -ERESTARTSYS;
 	if (*f_pos > dev->size) 
 		goto nothing;
@@ -194,13 +196,13 @@ ssize_t scullp_read (struct file *filp, char __user *buf, size_t count,
 		retval = -EFAULT;
 		goto nothing;
 	}
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 
 	*f_pos += count;
 	return count;
 
   nothing:
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 
@@ -217,7 +219,7 @@ ssize_t scullp_write (struct file *filp, const char __user *buf, size_t count,
 	int item, s_pos, q_pos, rest;
 	ssize_t retval = -ENOMEM; /* our most likely error */
 
-	if (down_interruptible (&dev->sem))
+	if (mutex_lock_interruptible(&dev->mutex))
 		return -ERESTARTSYS;
 
 	/* find listitem, qset index and offset in the quantum */
@@ -252,11 +254,11 @@ ssize_t scullp_write (struct file *filp, const char __user *buf, size_t count,
     	/* update the size */
 	if (dev->size < *f_pos)
 		dev->size = *f_pos;
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return count;
 
   nomem:
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 
@@ -384,78 +386,6 @@ loff_t scullp_llseek (struct file *filp, loff_t off, int whence)
 	return newpos;
 }
 
-
-/*
- * A simple asynchronous I/O implementation.
- */
-
-struct async_work {
-	struct kiocb *iocb;
-	int result;
-	struct delayed_work work;
-};
-
-/*
- * "Complete" an asynchronous operation.
- */
-static void scullp_do_deferred_op(struct work_struct *work)
-{
-	struct async_work *stuff = container_of(work, struct async_work, work.work);
-	aio_complete(stuff->iocb, stuff->result, 0);
-	kfree(stuff);
-}
-
-
-static int scullp_defer_op(int write, struct kiocb *iocb, const struct iovec *iovec,
-			   unsigned long nr_segs, loff_t pos)
-{
-	struct async_work *stuff;
-	int result = 0;
-	size_t len = 0;
-	unsigned long seg = 0;
-
-	/* Copy now while we can access the buffer */
-	for (seg = 0; seg < nr_segs; seg++) {
-		if (write)
-			len = scullp_write(iocb->ki_filp, iovec[seg].iov_base, iovec[seg].iov_len, &pos);
-		else
-			len = scullp_read(iocb->ki_filp, iovec[seg].iov_base, iovec[seg].iov_len, &pos);
-
-		if (len < 0)
-			return len;
-
-		result += len;
-	}
-
-	/* If this is a synchronous IOCB, we return our status now. */
-	if (is_sync_kiocb(iocb))
-		return result;
-
-	/* Otherwise defer the completion for a few milliseconds. */
-	stuff = kmalloc (sizeof (*stuff), GFP_KERNEL);
-	if (stuff == NULL)
-		return result; /* No memory, just complete now */
-	stuff->iocb = iocb;
-	stuff->result = result;
-	INIT_DELAYED_WORK(&stuff->work, scullp_do_deferred_op);
-	schedule_delayed_work(&stuff->work, HZ/100);
-	return -EIOCBQUEUED;
-}
-
-
-static ssize_t scullp_aio_read(struct kiocb *iocb, const struct iovec *iovec,
-			       unsigned long nr_segs, loff_t pos)
-{
-	return scullp_defer_op(0, iocb, iovec, nr_segs, pos);
-}
-
-static ssize_t scullp_aio_write(struct kiocb *iocb, const struct iovec *iovec, 
-				unsigned long nr_segs, loff_t pos)
-{
-	return scullp_defer_op(1, iocb, iovec, nr_segs, pos);
-}
-
-
  
 /*
  * Mmap *is* available, but confined in a different file
@@ -476,8 +406,8 @@ struct file_operations scullp_fops = {
 	.mmap =	     scullp_mmap,
 	.open =	     scullp_open,
 	.release =   scullp_release,
-	.aio_read =  scullp_aio_read,
-	.aio_write = scullp_aio_write,
+	.read_iter =  scull_read_iter,
+	.write_iter = scull_write_iter,
 };
 
 int scullp_trim(struct scullp_dev *dev)
@@ -561,7 +491,7 @@ int scullp_init(void)
 	for (i = 0; i < scullp_devs; i++) {
 		scullp_devices[i].order = scullp_order;
 		scullp_devices[i].qset = scullp_qset;
-		sema_init (&scullp_devices[i].sem, 1);
+		mutex_init(&scullp_devices[i].mutex);
 		scullp_setup_cdev(scullp_devices + i, i);
 	}
 

--- a/scullp/main.c
+++ b/scullp/main.c
@@ -280,9 +280,9 @@ long scullp_ioctl (struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	if (err)
 		return -EFAULT;
 

--- a/scullp/mmap.c
+++ b/scullp/mmap.c
@@ -57,16 +57,17 @@ void scullp_vma_close(struct vm_area_struct *vma)
  * is individually decreased, and would drop to 0.
  */
 
-static int scullp_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int scullp_vma_nopage(struct vm_fault *vmf)
 {
 	unsigned long offset;
+	struct vm_area_struct *vma = vmf->vma;
 	struct scullp_dev *ptr, *dev = vma->vm_private_data;
 	struct page *page = NULL;
 	void *pageptr = NULL; /* default to "missing" */
 	int retval = VM_FAULT_NOPAGE;
 
-	down(&dev->sem);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	mutex_lock(&dev->mutex);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*
@@ -89,7 +90,7 @@ static int scullp_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
 	retval = 0;
 
   out:
-	up(&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 

--- a/scullp/scull-shared/scull-async.c
+++ b/scullp/scull-shared/scull-async.c
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.c

--- a/scullp/scull-shared/scull-async.h
+++ b/scullp/scull-shared/scull-async.h
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.h

--- a/scullp/scullp.h
+++ b/scullp/scullp.h
@@ -60,7 +60,7 @@ struct scullp_dev {
 	int order;                /* the current allocation order */
 	int qset;                 /* the current array size */
 	size_t size;              /* 32-bit will suffice */
-	struct semaphore sem;     /* Mutual exclusion */
+	struct mutex mutex;     /* Mutual exclusion */
 	struct cdev cdev;
 };
 

--- a/scullv/Makefile
+++ b/scullv/Makefile
@@ -16,7 +16,7 @@ TARGET = scullv
 
 ifneq ($(KERNELRELEASE),)
 
-scullv-objs := main.o mmap.o
+scullv-objs := main.o mmap.o scull-shared/scull-async.o
 
 obj-m	:= scullv.o
 

--- a/scullv/main.c
+++ b/scullv/main.c
@@ -280,9 +280,9 @@ long scullv_ioctl (struct file *filp, unsigned int cmd, unsigned long arg)
 	 * "write" is reversed
 	 */
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		err = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+		err = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		err =  !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+		err =  !access_ok((void __user *)arg, _IOC_SIZE(cmd));
 	if (err)
 		return -EFAULT;
 

--- a/scullv/main.c
+++ b/scullv/main.c
@@ -29,6 +29,7 @@
 #include <linux/aio.h>
 #include <linux/uaccess.h>
 #include <linux/vmalloc.h>
+#include "scull-shared/scull-async.h"
 #include "scullv.h"		/* local definitions */
 
 
@@ -68,7 +69,7 @@ int scullv_read_procmem(struct seq_file *m, void *v)
 
 	for(i = 0; i < scullv_devs; i++) {
 		d = &scullv_devices[i];
-		if (down_interruptible (&d->sem))
+		if (down_interruptible (&d->mutex))
 			return -ERESTARTSYS;
 		qset = d->qset;  /* retrieve the features of each device */
 		order = d->order;
@@ -87,7 +88,7 @@ int scullv_read_procmem(struct seq_file *m, void *v)
 				}
 		}
 	  out:
-		up (&scullv_devices[i].sem);
+		up (&scullv_devices[i].mutex);
 		if (m->count > limit)
 			break;
 	}
@@ -122,10 +123,10 @@ int scullv_open (struct inode *inode, struct file *filp)
 
     	/* now trim to 0 the length of the device if open was write-only */
 	if ( (filp->f_flags & O_ACCMODE) == O_WRONLY) {
-		if (down_interruptible (&dev->sem))
+		if (mutex_lock_interruptible(&dev->mutex))
 			return -ERESTARTSYS;
 		scullv_trim(dev); /* ignore errors */
-		up (&dev->sem);
+		mutex_unlock(&dev->mutex);
 	}
 
 	/* and use filp->private_data to point to the device data */
@@ -170,7 +171,7 @@ ssize_t scullv_read (struct file *filp, char __user *buf, size_t count,
 	int item, s_pos, q_pos, rest;
 	ssize_t retval = 0;
 
-	if (down_interruptible (&dev->sem))
+	if (mutex_lock_interruptible(&dev->mutex))
 		return -ERESTARTSYS;
 	if (*f_pos > dev->size) 
 		goto nothing;
@@ -195,13 +196,13 @@ ssize_t scullv_read (struct file *filp, char __user *buf, size_t count,
 		retval = -EFAULT;
 		goto nothing;
 	}
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 
 	*f_pos += count;
 	return count;
 
   nothing:
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 
@@ -218,7 +219,7 @@ ssize_t scullv_write (struct file *filp, const char __user *buf, size_t count,
 	int item, s_pos, q_pos, rest;
 	ssize_t retval = -ENOMEM; /* our most likely error */
 
-	if (down_interruptible (&dev->sem))
+	if (mutex_lock_interruptible(&dev->mutex))
 		return -ERESTARTSYS;
 
 	/* find listitem, qset index and offset in the quantum */
@@ -252,11 +253,11 @@ ssize_t scullv_write (struct file *filp, const char __user *buf, size_t count,
     	/* update the size */
 	if (dev->size < *f_pos)
 		dev->size = *f_pos;
-	up (&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return count;
 
   nomem:
-	up (&dev->sem);
+    mutex_unlock(&dev->mutex);
 	return retval;
 }
 
@@ -384,79 +385,6 @@ loff_t scullv_llseek (struct file *filp, loff_t off, int whence)
 	return newpos;
 }
 
-
-/*
- * A simple asynchronous I/O implementation.
- */
-
-struct async_work {
-	struct kiocb *iocb;
-	int result;
-	struct delayed_work work;
-};
-
-/*
- * "Complete" an asynchronous operation.
- */
-static void scullv_do_deferred_op(struct work_struct *work)
-{
-	struct async_work *stuff = container_of(work, struct async_work, work.work);
-	aio_complete(stuff->iocb, stuff->result, 0);
-	kfree(stuff);
-}
-
-
-static int scullv_defer_op(int write, struct kiocb *iocb, const struct iovec *iovec,
-			   unsigned long nr_segs, loff_t pos)
-{
-	struct async_work *stuff;
-	int result = 0;
-	size_t len = 0;
-	unsigned long seg = 0;
-
-	/* Copy now while we can access the buffer */
-	for (seg = 0; seg < nr_segs; seg++) {
-		if (write)
-			len = scullv_write(iocb->ki_filp, iovec[seg].iov_base, iovec[seg].iov_len, &pos);
-		else
-			len = scullv_read(iocb->ki_filp, iovec[seg].iov_base, iovec[seg].iov_len, &pos);
-
-		if (len < 0)
-			return len;
-
-		result += len;
-	}
-
-	/* If this is a synchronous IOCB, we return our status now. */
-	if (is_sync_kiocb(iocb))
-		return result;
-
-	/* Otherwise defer the completion for a few milliseconds. */
-	stuff = kmalloc (sizeof (*stuff), GFP_KERNEL);
-	if (stuff == NULL)
-		return result; /* No memory, just complete now */
-	stuff->iocb = iocb;
-	stuff->result = result;
-	INIT_DELAYED_WORK(&stuff->work, scullv_do_deferred_op);
-	schedule_delayed_work(&stuff->work, HZ/100);
-	return -EIOCBQUEUED;
-}
-
-
-static ssize_t scullv_aio_read(struct kiocb *iocb, const struct iovec *iovec,
-			       unsigned long nr_segs, loff_t pos)
-{
-	return scullv_defer_op(0, iocb, iovec, nr_segs, pos);
-}
-
-static ssize_t scullv_aio_write(struct kiocb *iocb, const struct iovec *iovec,
-				unsigned long nr_segs, loff_t pos)
-{
-	return scullv_defer_op(1, iocb, iovec, nr_segs, pos);
-}
-
-
- 
 /*
  * Mmap *is* available, but confined in a different file
  */
@@ -476,8 +404,8 @@ struct file_operations scullv_fops = {
 	.mmap =	     scullv_mmap,
 	.open =	     scullv_open,
 	.release =   scullv_release,
-	.aio_read =  scullv_aio_read,
-	.aio_write = scullv_aio_write,
+	.read_iter =  scull_read_iter,
+	.write_iter = scull_write_iter,
 };
 
 int scullv_trim(struct scullv_dev *dev)
@@ -560,7 +488,7 @@ int scullv_init(void)
 	for (i = 0; i < scullv_devs; i++) {
 		scullv_devices[i].order = scullv_order;
 		scullv_devices[i].qset = scullv_qset;
-		sema_init (&scullv_devices[i].sem, 1);
+		mutex_init(&scullv_devices[i].mutex);
 		scullv_setup_cdev(scullv_devices + i, i);
 	}
 

--- a/scullv/mmap.c
+++ b/scullv/mmap.c
@@ -57,16 +57,17 @@ void scullv_vma_close(struct vm_area_struct *vma)
  * is individually decreased, and would drop to 0.
  */
 
-static int scullv_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int scullv_vma_nopage(struct vm_fault *vmf)
 {
 	unsigned long offset;
+	struct vm_area_struct *vma = vmf->vma;
 	struct scullv_dev *ptr, *dev = vma->vm_private_data;
 	struct page *page = NULL;
 	void *pageptr = NULL; /* default to "missing" */
 	int retval = VM_FAULT_NOPAGE;
 
-	down(&dev->sem);
-	offset = (unsigned long)(vmf->virtual_address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
+	mutex_lock(&dev->mutex);
+	offset = (unsigned long)(vmf->address - vma->vm_start) + (vma->vm_pgoff << PAGE_SHIFT);
 	if (offset >= dev->size) goto out; /* out of range */
 
 	/*
@@ -95,7 +96,7 @@ static int scullv_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
 	retval = 0;
 
   out:
-	up(&dev->sem);
+	mutex_unlock(&dev->mutex);
 	return retval;
 }
 

--- a/scullv/scull-shared/scull-async.c
+++ b/scullv/scull-shared/scull-async.c
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.c

--- a/scullv/scull-shared/scull-async.h
+++ b/scullv/scull-shared/scull-async.h
@@ -1,0 +1,1 @@
+../../scull-shared/scull-async.h

--- a/scullv/scullv.h
+++ b/scullv/scullv.h
@@ -60,7 +60,7 @@ struct scullv_dev {
 	int order;                /* the current allocation order */
 	int qset;                 /* the current array size */
 	size_t size;              /* 32-bit will suffice */
-	struct semaphore sem;     /* Mutual exclusion */
+	struct mutex mutex;     /* Mutual exclusion */
 	struct cdev cdev;
 };
 

--- a/shortprint/shortprint.c
+++ b/shortprint/shortprint.c
@@ -80,7 +80,7 @@ static unsigned long shortp_in_buffer = 0;
 static unsigned long volatile shortp_in_head;
 static volatile unsigned long shortp_in_tail;
 DECLARE_WAIT_QUEUE_HEAD(shortp_in_queue);
-static struct timeval shortp_tv;  /* When the interrupt happened. */
+static struct timespec64 shortp_tv;  /* When the interrupt happened. */
 
 /*
  * Atomicly increment an index into shortp_in_buffer
@@ -101,7 +101,7 @@ static inline void shortp_incr_bp(volatile unsigned long *index, int delta)
  */
 static unsigned char *shortp_out_buffer = NULL;
 static volatile unsigned char *shortp_out_head, *shortp_out_tail;
-static struct semaphore shortp_out_sem;
+static struct mutex shortp_out_mutex;
 static DECLARE_WAIT_QUEUE_HEAD(shortp_out_queue);
 
 /*
@@ -274,11 +274,11 @@ static ssize_t shortp_write(struct file *filp, const char __user *buf, size_t co
 	int space, written = 0;
 	unsigned long flags;
 	/*
-	 * Take and hold the semaphore for the entire duration of the operation.  The
+	 * Take and hold the mutex for the entire duration of the operation.  The
 	 * consumer side ignores it, and it will keep other data from interleaving
 	 * with ours.
 	 */
-	if (down_interruptible(&shortp_out_sem))
+	if (mutex_lock_interruptible(&shortp_out_mutex))
 		return -ERESTARTSYS;
 	/*
 	 * Out with the data.
@@ -296,7 +296,7 @@ static ssize_t shortp_write(struct file *filp, const char __user *buf, size_t co
 		if ((space + written) > count)
 			space = count - written;
 		if (copy_from_user((char *) shortp_out_head, buf, space)) {
-			up(&shortp_out_sem);
+			mutex_unlock(&shortp_out_mutex);
 			return -EFAULT;
 		}
 		shortp_incr_out_bp(&shortp_out_head, space);
@@ -312,7 +312,7 @@ static ssize_t shortp_write(struct file *filp, const char __user *buf, size_t co
 
 out:
 	*f_pos += written;
-	up(&shortp_out_sem);
+	mutex_unlock(&shortp_out_mutex);
 	return written;
 }
 
@@ -349,9 +349,9 @@ static void shortp_do_work(struct work_struct *work)
 	spin_unlock_irqrestore(&shortp_out_lock, flags);
 
 	/* Handle the "read" side operation */
-	written = sprintf((char *)shortp_in_head, "%08u.%06u\n",
+	written = sprintf((char *)shortp_in_head, "%08u.%09u\n",
 			(int)(shortp_tv.tv_sec % 100000000),
-			(int)(shortp_tv.tv_usec));
+			(int)(shortp_tv.tv_nsec));
 	shortp_incr_bp(&shortp_in_head, written);
 	wake_up_interruptible(&shortp_in_queue); /* awake any reading process */
 }
@@ -366,7 +366,7 @@ static irqreturn_t shortp_interrupt(int irq, void *dev_id)
 		return IRQ_NONE;
 
 	/* Remember the time, and farm off the rest to the workqueue function */ 
-	do_gettimeofday(&shortp_tv);
+	ktime_get_real_ts64(&shortp_tv);
 	queue_work(shortp_workqueue, &shortp_work);
 	return IRQ_HANDLED;
 }
@@ -456,7 +456,7 @@ static int shortp_init(void)
 	/* And the output buffer. */
 	shortp_out_buffer = (unsigned char *) __get_free_pages(GFP_KERNEL, 0);
 	shortp_out_head = shortp_out_tail = shortp_out_buffer;
-	sema_init(&shortp_out_sem, 1);
+	mutex_init(&shortp_out_mutex);
     
 	/* And the output info */
 	shortp_output_active = 0;

--- a/simple/simple.c
+++ b/simple/simple.c
@@ -90,11 +90,12 @@ static int simple_remap_mmap(struct file *filp, struct vm_area_struct *vma)
 /*
  * The nopage version.
  */
-static int simple_vma_nopage(struct vm_area_struct *vma, struct vm_fault *vmf)
+static int simple_vma_nopage(struct vm_fault *vmf)
 {
 	struct page *pageptr;
+	struct vm_area_struct *vma = vmf->vma;
 	unsigned long offset = vma->vm_pgoff << PAGE_SHIFT;
-	unsigned long physaddr = (unsigned long) vmf->virtual_address - vma->vm_start + offset;
+	unsigned long physaddr = (unsigned long) vmf->address - vma->vm_start + offset;
 	unsigned long pageframe = physaddr >> PAGE_SHIFT;
 
 // Eventually remove these printks


### PR DESCRIPTION
A rollup of changes from [Advanced Embedded Software Development](https://sites.google.com/colorado.edu/ecen5013/home) Fall 2019 semester, focusing on adding support for 5.x kernels, Ubuntu 18.04 native builds, 2018.05 Buildroot release, and warrior branch of Yocto project.

Summary of Changes
* Added eclipse support for ease of source code browsing/searching, see comments in the README file.
* Disabled sbull, snull, and short modules which are not compiling on 5.0 at this time.
* Modified access_ok wrapper to support kernel versions above or below 5.0
* Added module_load and module_unload scripts to misc-modules.
* Fixed several 5.x kernel build issues across several kernel modules.
* Added misc-progs/test/nonblock.sh script to help with testing of non blocking IO
* Added scull-shared directory and symlinks to avoid duplicating logic for components shared across all scull implementations.
* Used mutex insetad of semaphore for semaphores used as mutexes.
