### PR TITLE
Update misc-modules for kernel v5.8

### DIFF
--- a/include/proc_ops_version.h
+++ b/include/proc_ops_version.h
@@ -1,0 +1,34 @@
+#ifndef _PROC_OPS_VERSION_H
+#define _PROC_OPS_VERSION_H
+
+#include <linux/version.h>
+
+#ifdef CONFIG_COMPAT
+#define __add_proc_ops_compat_ioctl(pops, fops)					\
+	(pops)->proc_compat_ioctl = (fops)->compat_ioctl
+#else
+#define __add_proc_ops_compat_ioctl(pops, fops)
+#endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)
+#define proc_ops_wrapper(fops, newname)	(fops)
+#else
+#define proc_ops_wrapper(fops, newname)						\
+({										\
+ 	static struct proc_ops newname;						\
+										\
+	newname.proc_open = (fops)->open;					\
+	newname.proc_read = (fops)->read;					\
+	newname.proc_write = (fops)->write;					\
+	newname.proc_release = (fops)->release;					\
+	newname.proc_poll = (fops)->poll;					\
+	newname.proc_ioctl = (fops)->unlocked_ioctl;				\
+	newname.proc_mmap = (fops)->mmap;					\
+	newname.proc_get_unmapped_area = (fops)->get_unmapped_area;		\
+	newname.proc_lseek = (fops)->llseek;					\
+	__add_proc_ops_compat_ioctl(&newname, fops);				\
+	&newname;								\
+})
+#endif
+
+#endif

--- a/misc-modules/Makefile
+++ b/misc-modules/Makefile
@@ -4,6 +4,10 @@
 # Makefile once again.
 # This conditional selects whether we are being included from the
 # kernel Makefile or not.
+
+LDDINC=$(PWD)/../include
+EXTRA_CFLAGS += -I$(LDDINC)
+
 ifeq ($(KERNELRELEASE),)
 
     # Assume the source tree is where the running kernel was built

--- a/misc-modules/jiq.c
+++ b/misc-modules/jiq.c
@@ -29,6 +29,7 @@
 #include <linux/preempt.h>
 #include <linux/interrupt.h> /* tasklets */
 
+#include "proc_ops_version.h"
 MODULE_LICENSE("Dual BSD/GPL");
 
 /*
@@ -273,10 +274,14 @@ static int jiq_init(void)
 	INIT_WORK(&jiq_data.jiq_work, jiq_print_wq);
 	INIT_DELAYED_WORK(&jiq_data.jiq_delayed_work, jiq_print_wq_delayed);
 
-	proc_create("jiqwq", 0, NULL, &jiq_read_wq_fops);
-	proc_create("jiqwqdelay", 0, NULL, &jiq_read_wq_delayed_fops);
-	proc_create("jitimer", 0, NULL, &jiq_read_run_timer_fops);
-	proc_create("jiqtasklet", 0, NULL, &jiq_read_tasklet_fops);
+	proc_create("jiqwq", 0, NULL,
+	    proc_ops_wrapper(&jiq_read_wq_fops, jiq_read_wq_pops));
+	proc_create("jiqwqdelay", 0, NULL,
+	    proc_ops_wrapper(&jiq_read_wq_delayed_fops, jiq_read_wq_delayed_pops));
+	proc_create("jitimer", 0, NULL,
+	    proc_ops_wrapper(&jiq_read_run_timer_fops, jiq_read_run_timer_pops));
+	proc_create("jiqtasklet", 0, NULL,
+	    proc_ops_wrapper(&jiq_read_tasklet_fops, jiq_read_tasklet_pops));
 
 	return 0; /* succeed */
 }

--- a/misc-modules/jit.c
+++ b/misc-modules/jit.c
@@ -32,6 +32,8 @@
 #include <linux/slab.h>
 #include <linux/version.h>
 #include <asm/hardirq.h>
+
+#include "proc_ops_version.h"
 /*
  * This module is a silly one: it only embeds short code fragments
  * that show how time delays can be handled in the kernel.
@@ -313,16 +315,23 @@ static const struct file_operations jit_tasklet_fops = {
 
 int __init jit_init(void)
 {
-	proc_create_data("currentime", 0, NULL, &jit_currentime_fops, NULL);
-	proc_create_data("jitbusy", 0, NULL, &jit_fn_fops, (void *)JIT_BUSY);
-	proc_create_data("jitsched", 0, NULL, &jit_fn_fops, (void *)JIT_SCHED);
-	proc_create_data("jitqueue", 0, NULL, &jit_fn_fops, (void *)JIT_QUEUE);
-	proc_create_data("jitschedto", 0, NULL, &jit_fn_fops,
-			(void *)JIT_SCHEDTO);
+	proc_create_data("currentime", 0, NULL,
+	    proc_ops_wrapper(&jit_currentime_fops, jit_currentime_pops), NULL);
+	proc_create_data("jitbusy", 0, NULL,
+	    proc_ops_wrapper(&jit_fn_fops, jit_fn_pops), (void *)JIT_BUSY);
+	proc_create_data("jitsched", 0, NULL,
+	    proc_ops_wrapper(&jit_fn_fops, jit_fn_pops), (void *)JIT_SCHED);
+	proc_create_data("jitqueue", 0, NULL,
+	    proc_ops_wrapper(&jit_fn_fops, jit_fn_pops), (void *)JIT_QUEUE);
+	proc_create_data("jitschedto", 0, NULL,
+	    proc_ops_wrapper(&jit_fn_fops, jit_fn_pops), (void *)JIT_SCHEDTO);
 
-	proc_create_data("jitimer", 0, NULL, &jit_timer_fops, NULL);
-	proc_create_data("jitasklet", 0, NULL, &jit_tasklet_fops, NULL);
-	proc_create_data("jitasklethi", 0, NULL, &jit_tasklet_fops, (void *)1);
+	proc_create_data("jitimer", 0, NULL,
+	    proc_ops_wrapper(&jit_timer_fops, jit_timer_pops), NULL);
+	proc_create_data("jitasklet", 0, NULL,
+	    proc_ops_wrapper(&jit_tasklet_fops, jit_tasklet_pops), NULL);
+	proc_create_data("jitasklethi", 0, NULL,
+	    proc_ops_wrapper(&jit_tasklet_fops, jit_tasklet_pops), (void *)1);
 
 	return 0; /* success */
 }

--- a/misc-modules/seq.c
+++ b/misc-modules/seq.c
@@ -11,6 +11,7 @@
 #include <linux/seq_file.h>
 #include <linux/slab.h>
 
+#include "proc_ops_version.h"
 
 MODULE_AUTHOR("Jonathan Corbet");
 MODULE_LICENSE("Dual BSD/GPL");
@@ -94,7 +95,8 @@ static int ct_init(void)
 {
 	struct proc_dir_entry *entry;
 
-	entry = proc_create("sequence", 0, NULL, &ct_file_ops);
+	entry = proc_create("sequence", 0, NULL,
+	    proc_ops_wrapper(&ct_file_ops, ct_file_pops));
 	if (!entry)
 		return -ENOMEM;
 	return 0;


### PR DESCRIPTION
Hello,
this is an updated code based on pull request https://github.com/martinezjavier/ldd3/pull/41 in regard to supporting the new `proc_ops` structure
additionally, i have updated jiq for linux kernel v5.8 (static tasklet with data are no longer supported; see commit message)

I have tested jit, jiq, seq with kernels v5.6, v5.7, and v5.8.