### PR TITLE
Remove redundant fops setting

### DIFF
--- a/scull/main.c
+++ b/scull/main.c
@@ -605,7 +605,6 @@ static void scull_setup_cdev(struct scull_dev *dev, int index)
     
 	cdev_init(&dev->cdev, &scull_fops);
 	dev->cdev.owner = THIS_MODULE;
-	dev->cdev.ops = &scull_fops;
 	err = cdev_add (&dev->cdev, devno, 1);
 	/* Fail gracefully if need be */
 	if (err)

--- a/scullc/main.c
+++ b/scullc/main.c
@@ -441,7 +441,6 @@ static void scullc_setup_cdev(struct scullc_dev *dev, int index)
     
 	cdev_init(&dev->cdev, &scullc_fops);
 	dev->cdev.owner = THIS_MODULE;
-	dev->cdev.ops = &scullc_fops;
 	err = cdev_add (&dev->cdev, devno, 1);
 	/* Fail gracefully if need be */
 	if (err)

--- a/sculld/main.c
+++ b/sculld/main.c
@@ -455,7 +455,6 @@ static void sculld_setup_cdev(struct sculld_dev *dev, int index)
     
 	cdev_init(&dev->cdev, &sculld_fops);
 	dev->cdev.owner = THIS_MODULE;
-	dev->cdev.ops = &sculld_fops;
 	err = cdev_add (&dev->cdev, devno, 1);
 	/* Fail gracefully if need be */
 	if (err)

--- a/scullv/main.c
+++ b/scullv/main.c
@@ -444,7 +444,6 @@ static void scullv_setup_cdev(struct scullv_dev *dev, int index)
     
 	cdev_init(&dev->cdev, &scullv_fops);
 	dev->cdev.owner = THIS_MODULE;
-	dev->cdev.ops = &scullv_fops;
 	err = cdev_add (&dev->cdev, devno, 1);
 	/* Fail gracefully if need be */
 	if (err)

--- a/simple/simple.c
+++ b/simple/simple.c
@@ -142,7 +142,6 @@ static void simple_setup_cdev(struct cdev *dev, int minor,
     
 	cdev_init(dev, fops);
 	dev->owner = THIS_MODULE;
-	dev->ops = fops;
 	err = cdev_add (dev, devno, 1);
 	/* Fail gracefully if need be */
 	if (err)


### PR DESCRIPTION
See https://github.com/martinezjavier/ldd3/issues/33
Based on https://github.com/torvalds/linux/blame/master/fs/char_dev.c#L656
fops has been set in cdev_init since at least 2.6.12.