### PR TITLE
add alpine 3.13 item in Latest Tested Kernel Builds section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The kernel builds below are the versions most recently tested/supported
 * Ubuntu 18.04 kernel as of July 2020: 5.4.0-42-generic
 * Yocto warrior branch kernel for qemu builds: 5.0.19
 * Buildroot 2019.05 kernel for qemu builds: 4.9.16
+* Alpine 3.13 kernel as of May 2021: 5.10.29-lts, see [here](https://github.com/ericwq/gccIDE/wiki/ldd3-project) for detail.
 
 
 # Eclipse Integration


### PR DESCRIPTION
ldd3 has been verified on alpine 3.13