### PR TITLE
jit: fix compilation of the module

### DIFF
--- a/misc-modules/jit.c
+++ b/misc-modules/jit.c
@@ -93,7 +93,7 @@ int jit_fn_show(struct seq_file *m, void *v)
 
 static int jit_fn_open(struct inode *inode, struct file *file)
 {
-	return single_open(file, jit_fn_show, PDE_DATA(inode));
+	return single_open(file, jit_fn_show, pde_data(inode));
 }
 
 static const struct file_operations jit_fn_fops = {
@@ -303,7 +303,7 @@ int jit_tasklet_show(struct seq_file *m, void *v)
 
 static int jit_tasklet_open(struct inode *inode, struct file *file)
 {
-	return single_open(file, jit_tasklet_show, PDE_DATA(inode));
+	return single_open(file, jit_tasklet_show, pde_data(inode));
 }
 
 static const struct file_operations jit_tasklet_fops = {


### PR DESCRIPTION
The module was using the PDE_DATA function (deprecated since 5.17) and the module wasn't compiling.

More about the PDE_DATA removal here: https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa