### PR TITLE
Fix mismatched `iowrite*` target size and some other compile errors

### DIFF
--- a/misc-modules/silly.c
+++ b/misc-modules/silly.c
@@ -212,7 +212,7 @@ ssize_t silly_write(struct file *filp, const char __user *buf, size_t count,
 	switch(mode) {
 	  case M_32: 
 		while (count >= 4) {
-			iowrite8(*(u32 *)ptr, add);
+			iowrite32(*(u32 *)ptr, add);
 			add += 4;
 			count -= 4;
 			ptr += 4;
@@ -221,7 +221,7 @@ ssize_t silly_write(struct file *filp, const char __user *buf, size_t count,
 	    
 	  case M_16: 
 		while (count >= 2) {
-			iowrite8(*(u16 *)ptr, add);
+			iowrite16(*(u16 *)ptr, add);
 			add += 2;
 			count -= 2;
 			ptr += 2;

--- a/tty/tiny_serial.c
+++ b/tty/tiny_serial.c
@@ -143,7 +143,7 @@ static void tiny_break_ctl(struct uart_port *port, int break_state)
 }
 
 static void tiny_set_termios(struct uart_port *port,
-			     struct ktermios *new, struct ktermios *old)
+			     struct ktermios *new, const struct ktermios *old)
 {
 	int baud, quot, cflag = new->c_cflag;
 	/* get the byte size */

--- a/tty/tiny_tty.c
+++ b/tty/tiny_tty.c
@@ -223,7 +223,7 @@ exit:
 
 #define RELEVANT_IFLAG(iflag) ((iflag) & (IGNBRK|BRKINT|IGNPAR|PARMRK|INPCK))
 
-static void tiny_set_termios(struct tty_struct *tty, struct ktermios *old_termios)
+static void tiny_set_termios(struct tty_struct *tty, const struct ktermios *old_termios)
 {
 	unsigned int cflag;
 

--- a/tty/tiny_tty.c
+++ b/tty/tiny_tty.c
@@ -511,7 +511,7 @@ static int __init tiny_init(void)
 	int i;
 
 	/* allocate the tty driver */
-	tiny_tty_driver = alloc_tty_driver(TINY_TTY_MINORS);
+	tiny_tty_driver = tty_alloc_driver(TINY_TTY_MINORS, 0);
 	if (!tiny_tty_driver)
 		return -ENOMEM;
 
@@ -535,7 +535,7 @@ static int __init tiny_init(void)
 	retval = tty_register_driver(tiny_tty_driver);
 	if (retval) {
 		pr_err("failed to register tiny tty driver");
-		put_tty_driver(tiny_tty_driver);
+		tty_driver_kref_put(tiny_tty_driver);
 		return retval;
 	}
 


### PR DESCRIPTION
- Fix `iowrite*` in `silly.c` to match the target size.
- Fix missing const qualifier in `tiny_set_termios`.
- Try to fix some other compile errors caused by the tty driver API changes, but I'm not sure whether it has been done correctly.
- `sbull` and `snull` are still not compiling. It seems that there are some significant changes that I haven't been able to figure out.