### PR TITLE
Fix compile failures caused by incorrect function arguments(Linux 6.3.5)

### DIFF
--- a/lddbus/lddbus.c
+++ b/lddbus/lddbus.c
@@ -30,7 +30,7 @@ static char *Version = "$Revision: 1.9 $";
 /*
  * Respond to udev events.
  */
-static int ldd_uevent(struct device *dev, struct kobj_uevent_env *env)
+static int ldd_uevent(const struct device *dev, struct kobj_uevent_env *env)
 {
 	if (add_uevent_var(env, "LDDBUS_VERSION=%s", Version))
 		return -ENOMEM;

--- a/lddbus/lddbus.c
+++ b/lddbus/lddbus.c
@@ -21,6 +21,7 @@
 #include <linux/kernel.h>
 #include <linux/init.h>
 #include <linux/string.h>
+#include <linux/version.h>
 #include "lddbus.h"
 
 MODULE_AUTHOR("Jonathan Corbet");
@@ -30,7 +31,11 @@ static char *Version = "$Revision: 1.9 $";
 /*
  * Respond to udev events.
  */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0))
+static int ldd_uevent(struct device *dev, struct kobj_uevent_env *env)
+#else
 static int ldd_uevent(const struct device *dev, struct kobj_uevent_env *env)
+#endif
 {
 	if (add_uevent_var(env, "LDDBUS_VERSION=%s", Version))
 		return -ENOMEM;


### PR DESCRIPTION
I compiled the lddbus module in the example code on arch Linux with Linux 6.3.5 kernel and found that `static int ldd_uevent(struct device *dev, struct kobj_uevent_env *env)` should be written as `const struct device *dev`, otherwise it will fail to compile.