### PR TITLE
Modify the code to support Linux 6.x

### DIFF
--- a/tty/tiny_serial.c
+++ b/tty/tiny_serial.c
@@ -141,9 +141,13 @@ static void tiny_set_mctrl(struct uart_port *port, unsigned int mctrl)
 static void tiny_break_ctl(struct uart_port *port, int break_state)
 {
 }
-
-static void tiny_set_termios(struct uart_port *port,
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
+	static void tiny_set_termios(struct uart_port *port,
 			     struct ktermios *new, struct ktermios *old)
+#else
+	static void tiny_set_termios(struct uart_port *port,
+			     struct ktermios *new, const struct ktermios *old)
+#endif
 {
 	int baud, quot, cflag = new->c_cflag;
 	/* get the byte size */

--- a/tty/tiny_tty.c
+++ b/tty/tiny_tty.c
@@ -223,7 +223,11 @@ exit:
 
 #define RELEVANT_IFLAG(iflag) ((iflag) & (IGNBRK|BRKINT|IGNPAR|PARMRK|INPCK))
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0))
 static void tiny_set_termios(struct tty_struct *tty, struct ktermios *old_termios)
+#else
+static void tiny_set_termios(struct tty_struct *tty, const struct ktermios *old_termios)
+#endif
 {
 	unsigned int cflag;
 
@@ -511,7 +515,11 @@ static int __init tiny_init(void)
 	int i;
 
 	/* allocate the tty driver */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 	tiny_tty_driver = alloc_tty_driver(TINY_TTY_MINORS);
+#else
+	tiny_tty_driver = tty_alloc_driver(TINY_TTY_MINORS, 0);
+#endif
 	if (!tiny_tty_driver)
 		return -ENOMEM;
 
@@ -535,7 +543,11 @@ static int __init tiny_init(void)
 	retval = tty_register_driver(tiny_tty_driver);
 	if (retval) {
 		pr_err("failed to register tiny tty driver");
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 		put_tty_driver(tiny_tty_driver);
+#else
+		tty_driver_kref_put(tiny_tty_driver);
+#endif
 		return retval;
 	}
 


### PR DESCRIPTION
In **tiny_tty.c**:
`alloc_tty_driver()` and `put_tty_driver()` has been deleted in Linux 5.15. See
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=56ec5880a28eae0f508e88e9e80d2e82a471c9be
and
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=9f90a4ddef4e4d3aa4229f6b117d4e57231457b3

`const struct tty_operations::set_ktermios(struct tty_struct *, struct ktermios *)`
==> `const struct tty_operations::set_ktermios(struct tty_struct *, const struct ktermios *)` See
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/include/linux/tty_driver.h?id=a8c11c1520347be74b02312d10ef686b01b525f1

In **tiny_serial.c**:
`struct uart_ops::set_termios(struct uart_port *, struct ktermios *, const struct ktermios *)`
==> `struct uart_ops::set_termios(struct uart_port *, struct ktermios *, const struct ktermios *)` See
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/include/linux/serial_core.h?id=bec5b814d46c2a704c3c8148752e62a33e9fa6dc