### PR TITLE
Wrap PDE_DATA calls with a linux kernel version

### DIFF
--- a/misc-modules/jit.c
+++ b/misc-modules/jit.c
@@ -93,7 +93,11 @@ int jit_fn_show(struct seq_file *m, void *v)
 
 static int jit_fn_open(struct inode *inode, struct file *file)
 {
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+	return single_open(file, jit_fn_show, PDE_DATA(inode));
+	#else
 	return single_open(file, jit_fn_show, pde_data(inode));
+	#endif
 }
 
 static const struct file_operations jit_fn_fops = {
@@ -303,7 +307,11 @@ int jit_tasklet_show(struct seq_file *m, void *v)
 
 static int jit_tasklet_open(struct inode *inode, struct file *file)
 {
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
+	return single_open(file, jit_tasklet_show, PDE_DATA(inode));
+	#else
 	return single_open(file, jit_tasklet_show, pde_data(inode));
+	#endif
 }
 
 static const struct file_operations jit_tasklet_fops = {


### PR DESCRIPTION
This addresses issue #80. I am taking Professor Walkes's course and needed this to be able to build an older kernel version (5.15.18) via Buildroot while on Debian 12. This is the only instance of pde_data in the repo. Let me know if there are any other tests you'd want me to run!

[Ubuntu 20 Focal Fossa](20.04 LTS (Focal Fossa)) is still in LTS support and uses [less than 5.17.0 for its kernel version.](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Linux_Kernel) 


https://github.com/torvalds/linux/commit/359745d78351c6f5442435f81549f0207ece28aa
^
Linux Remove PDE_DATA PR

Edit: Walkes, not walker sorry!