### PR TITLE
Fix known issues in the snull driver

### DIFF
--- a/snull/snull.c
+++ b/snull/snull.c
@@ -140,13 +140,15 @@ static struct snull_packet *snull_get_tx_buffer(struct net_device *dev)
 	pkt = priv->ppool;
 	if(!pkt) {
 		PDEBUG("Out of Pool\n");
-		return pkt;
+		goto out;
 	}
 	priv->ppool = pkt->next;
 	if (priv->ppool == NULL) {
 		printk (KERN_INFO "Pool empty\n");
 		netif_stop_queue(dev);
 	}
+
+out:
 	spin_unlock_irqrestore(&priv->lock, flags);
 	return pkt;
 }

--- a/snull/snull.c
+++ b/snull/snull.c
@@ -428,9 +428,9 @@ static void snull_napi_interrupt(int irq, void *dev_id, struct pt_regs *regs)
 	/* retrieve statusword: real netdevices use I/O instructions */
 	statusword = priv->status;
 	priv->status = 0;
-	if (statusword & SNULL_RX_INTR) {
+	if (statusword & SNULL_RX_INTR && napi_schedule_prep(&priv->napi)) {
 		snull_rx_ints(dev, 0);  /* Disable further interrupts */
-		napi_schedule(&priv->napi);
+		__napi_schedule(&priv->napi);
 	}
 	if (statusword & SNULL_TX_INTR) {
         	/* a transmission is over: free the skb */


### PR DESCRIPTION
- Fixed #73 
- Resolved issue #68 and credited @lzq420241 in the commit.
- In the `snull_init_module(void)` if the first device registration fails, the second iteration of the loop will set the `ret` to zero. Also, jumping to `snull_cleanup()` will put the device into `unreg` queue which is unnecessary.