### PR TITLE
Use correct arguments for insmod in module_load

### DIFF
--- a/misc-modules/module_load
+++ b/misc-modules/module_load
@@ -21,6 +21,9 @@ else
     group="wheel"
 fi
 
+# Discard the module name before passing arguments to insmod
+shift
+
 echo "Load our module, exit on failure"
 insmod ./$module.ko $* || exit 1
 echo "Get the major number (allocated with allocate_chrdev_region) from /proc/devices"


### PR DESCRIPTION
In the module_load script, the first argument, module, is passed as the an argument to insmod: 
`insmod ./$module.ok $module ...`
becase `$*` includes the first argument $module

Use shift to drop the first argument and pass the remaining arguments to insmod.