### PR TITLE
Fix: proc_dir_entry 'driver/tiny_tty' already registered

### DIFF
--- a/tty/tiny_tty.c
+++ b/tty/tiny_tty.c
@@ -556,6 +556,7 @@ static void __exit tiny_exit(void)
 		tty_port_destroy(tiny_tty_port + i);
 	}
 	tty_unregister_driver(tiny_tty_driver);
+	put_tty_driver(tiny_tty_driver);
 
 	/* shut down all of the timers and free the memory */
 	for (i = 0; i < TINY_TTY_MINORS; ++i) {


### PR DESCRIPTION
### Reason: /proc/tty/driver/tiny_tty has not been removed in tiny_exit()
```sh
$ sudo insmod tiny_tty.ko 

$ sudo rmmod tiny_tty 

$ lsmod | grep tiny_tty

$ sudo find /proc -name "tiny*"

   /proc/tty/driver/tiny_tty
```

### Trigger the error / warning

```sh
$ sudo insmod tiny_tty.ko 
$ dmesg

   proc_dir_entry 'driver/tiny_tty' already registered
```