### PR TITLE
Fix error: implicit declaration of function ‘exit’ on misc-progs/mapper.c

### DIFF
--- a/misc-progs/mapper.c
+++ b/misc-progs/mapper.c
@@ -24,6 +24,7 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
It happens on Ubuntu 24.10 GCC 14.2 presumably due to more strict error checking having become the default.