### PR TITLE
Remove kernel -I include from userland example to prevent conflicting declaration errors

### DIFF
--- a/misc-progs/Makefile
+++ b/misc-progs/Makefile
@@ -2,9 +2,7 @@
 FILES = asynctest nbtest load50 mapcmp polltest mapper setlevel setconsole inp outp \
 	datasize dataalign netifdebug
 
-KERNELDIR ?= /lib/modules/$(shell uname -r)/build
-INCLUDEDIR = $(KERNELDIR)/include
-CFLAGS = -O2 -fomit-frame-pointer -Wall -I$(INCLUDEDIR)
+CFLAGS = -O2 -fomit-frame-pointer -Wall
 
 all: $(FILES)
 


### PR DESCRIPTION
Before this commit building against kernel v5.10.236 (latest under v5.10 which is the latest minor the README claims to work) was failing with errors such as:

```
cc -O2 -fomit-frame-pointer -Wall -I/home/ciro/bak/git/linux-kernel-module-cheat/submodules/ldd3/../../data/linux/v5.10/include    mapper.c   -o mapper
In file included from /usr/include/stdlib.h:514,
                 from mapper.c:27:
/usr/include/x86_64-linux-gnu/sys/types.h:42:18: error: conflicting types for ‘loff_t’; have ‘__loff_t’ {aka ‘long int’}
   42 | typedef __loff_t loff_t;
      |                  ^~~~~~
In file included from /home/ciro/bak/git/linux-kernel-module-cheat/submodules/ldd3/../../data/linux/v5.10/include/linux/limits.h:6,
                 from /usr/include/x86_64-linux-gnu/bits/local_lim.h:38,
                 from /usr/include/x86_64-linux-gnu/bits/posix1_lim.h:161,
                 from /usr/include/limits.h:195,
                 from /usr/lib/gcc/x86_64-linux-gnu/14/include/limits.h:210,
                 from /usr/lib/gcc/x86_64-linux-gnu/14/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-linux-gnu/14/include/limits.h:34,
                 from mapper.c:26:
/home/ciro/bak/git/linux-kernel-module-cheat/submodules/ldd3/../../data/linux/v5.10/include/linux/types.h:46:33: note: previous declaration of ‘loff_t’ with type ‘loff_t’ {aka ‘long long int’}
   46 | typedef __kernel_loff_t         loff_t;
      |                                 ^~~~~~
```

because the build was adding the built kernel's include directory to the build of userland programs, which leads to multiple incompatible definitions of certain types.

I don't think this is ever the correct thing to do, the C standard library should be insulated and work on any kernel new enough on the correct arch.

Removing the include it makes the build work tested on Ubuntu 24.10 amd64 GCC 14.2.0.