### PR TITLE
Fix static BUS_ATTR_RO(version); first arg is now const

### DIFF
--- a/lddbus/lddbus.c
+++ b/lddbus/lddbus.c
@@ -77,7 +77,13 @@ struct bus_type ldd_bus_type = {
 /*
  * Export a simple attribute.
  */
+/* Changed in kernel commit 75cff725d9566699a670a02b3cfd1c6e9e9ed53e
+ * driver core: bus: mark the struct bus_type for sysfs callbacks as constant */
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0))
 static ssize_t version_show(struct bus_type *bus, char *buf)
+#else
+static ssize_t version_show(const struct bus_type *bus, char *buf)
+#endif
 {
 	return snprintf(buf, PAGE_SIZE, "%s\n", Version);
 }


### PR DESCRIPTION
Tested on kernel v6.6.88, build was failing with:

```
/root/lkmc/submodules/ldd3/lddbus/lddbus.c:85:20: error: initialization of 'ssize_t (*)(const struct bus_type *, char *)' {aka 'long int (*)(const struct
 bus_type *, char *)'} from incompatible pointer type 'ssize_t (*)(struct bus_type *, char *)' {aka 'long int (*)(struct bus_type *, char *)'} [-Werror=i
ncompatible-pointer-types]
   85 | static BUS_ATTR_RO(version);
      |                    ^~~~~~~
```

This commit fixes that and that file now builds. The rest of the build continues to fail on other errors that follow as before.

I've also tested the build on kernel v5.10.236, the latest patch on 5.10 which the README says should work, and it still builds.

Tested on Ubuntu 24.10 GCC 14.2.0.